### PR TITLE
feat: add global styles and responsive palette

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,42 +6,8 @@
   <link rel="stylesheet" href="https://unpkg.com/bootstrap-vue@2.21.2/dist/bootstrap-vue.css">
   <link rel="stylesheet" href="https://unpkg.com/leaflet@1.7.1/dist/leaflet.css" />
   <link rel="stylesheet" href="https://cdn.knightlab.com/libs/juxtapose/latest/css/juxtapose.css">
-  <style>
-    body, html {
-      height: 100%;
-      margin: 0;
-      padding: 0;
-    }
-    #map {
-      position: fixed;
-      top: 60px;
-      left: 0;
-      right: 0;
-      bottom: 0;
-      transition: left 0.3s ease;
-    }
-    #map.sidebar-open {
-      left: 250px;
-    }
-    .navbar {
-      position: fixed;
-      top: 0;
-      width: 100%;
-      z-index: 1002;  /* Increase z-index value */
-      box-shadow: 0 2px 4px rgba(0,0,0,0.1);
-      background-color: #f8f9fa;
-    }
-    #sidebar::-webkit-scrollbar {
-      width: 0.5em;
-    }
-    #sidebar::-webkit-scrollbar-track {
-      box-shadow: inset 0 0 6px rgba(0, 0, 0, 0.3);
-    }
-    #sidebar::-webkit-scrollbar-thumb {
-      background-color: darkgrey;
-      outline: 1px solid slategrey;
-    }
-  </style>
+  <link href="https://fonts.googleapis.com/css2?family=Inter&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="styles.css">
   <script src="https://unpkg.com/vue@2.6.12/dist/vue.js"></script>
   <script src="https://unpkg.com/bootstrap-vue@2.21.2/dist/bootstrap-vue.js"></script>
   <script src="https://unpkg.com/leaflet@1.7.1/dist/leaflet.js"></script>
@@ -60,9 +26,9 @@
       </b-collapse>
     </b-navbar>
 
-    <b-sidebar id="sidebar" title="Choose List" :visible="sidebarOpen" @change="handleSidebarChange" @hidden="sidebarOpen = false" bg-variant="dark" text-variant="light">
-      <b-form-checkbox v-model="showList1" switch inline class="text-light">List 1</b-form-checkbox>
-      <b-form-checkbox v-model="showList2" switch inline class="text-light">List 2</b-form-checkbox>
+    <b-sidebar id="sidebar" title="Choose List" :visible="sidebarOpen" @change="handleSidebarChange" @hidden="sidebarOpen = false">
+      <b-form-checkbox v-model="showList1" switch inline>List 1</b-form-checkbox>
+      <b-form-checkbox v-model="showList2" switch inline>List 2</b-form-checkbox>
     </b-sidebar>
 
     <div id="map" :class="{ 'sidebar-open': sidebarOpen }"></div>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,86 @@
+:root {
+  --accent: #1E75B6;
+  --secondary: #7ED957;
+  --light: #F2F4F7;
+  --text: #1B1B1B;
+}
+body, html {
+  height: 100%;
+  margin: 0;
+  padding: 0;
+}
+body {
+  font-family: 'Inter', sans-serif;
+  color: var(--text);
+}
+#map {
+  position: fixed;
+  top: 60px;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  transition: left 0.3s ease;
+}
+#map.sidebar-open {
+  left: 250px;
+}
+.navbar {
+  position: fixed;
+  top: 0;
+  width: 100%;
+  z-index: 1002;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+.navbar,
+.btn-info {
+  background-color: var(--accent) !important;
+  color: #fff !important;
+  border-color: var(--accent) !important;
+}
+.navbar .navbar-brand,
+.navbar .nav-link {
+  color: #fff !important;
+}
+#sidebar {
+  width: 250px;
+  background: var(--light);
+  color: var(--text);
+}
+#sidebar::-webkit-scrollbar {
+  width: 0.5em;
+}
+#sidebar::-webkit-scrollbar-track {
+  box-shadow: inset 0 0 6px rgba(0, 0, 0, 0.3);
+}
+#sidebar::-webkit-scrollbar-thumb {
+  background-color: darkgrey;
+  outline: 1px solid slategrey;
+}
+.custom-control-input:checked~.custom-control-label::before {
+  background-color: var(--accent);
+  border-color: var(--accent);
+}
+.details-button {
+  display: inline-block;
+  background: var(--accent);
+  color: #fff;
+  padding: 6px 12px;
+  border-radius: 4px;
+  text-decoration: none;
+}
+.details-button:hover {
+  background: var(--secondary);
+  color: #fff;
+}
+@media (max-width: 768px) {
+  #sidebar {
+    width: 200px;
+  }
+  #map.sidebar-open {
+    left: 200px;
+  }
+  .details-button {
+    padding: 4px 8px;
+    font-size: 14px;
+  }
+}


### PR DESCRIPTION
## Summary
- add global `styles.css` with color palette, font and responsive sidebar
- move inline styles to external stylesheet
- hook up Inter font and theme Bootstrap-Vue components to palette

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c8ea2b1e48333ba7d7ccaef12f1ac